### PR TITLE
Increase max-line-length

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,9 @@
 [flake8]
+
+# Maximum number of characters on a single line.  Ideally, lines should be under 79 characters,
+# but we allow some leeway before calling it an error.
+max-line-length = 90
+
 ignore = 
     # D401 First line should be in imperative mood
     D401,


### PR DESCRIPTION
The default maximum number of characters on a single line is 79.  However, sometimes complex formulas may lead to over-length. For the sake of readability, we allow some leeway before calling it an error.