### PR TITLE
Accelerate DataLoader

### DIFF
--- a/matchzoo/auto/preparer/prepare.py
+++ b/matchzoo/auto/preparer/prepare.py
@@ -1,11 +1,11 @@
 import typing
 
 import matchzoo as mz
-from .preparer import Preparer
-from matchzoo.engine.base_task import BaseTask
-from matchzoo.engine.base_model import BaseModel
 from matchzoo.engine.base_callback import BaseCallback
+from matchzoo.engine.base_model import BaseModel
 from matchzoo.engine.base_preprocessor import BasePreprocessor
+from matchzoo.engine.base_task import BaseTask
+from .preparer import Preparer
 
 
 def prepare(
@@ -16,6 +16,7 @@ def prepare(
     preprocessor: typing.Optional[BasePreprocessor] = None,
     embedding: typing.Optional['mz.Embedding'] = None,
     config: typing.Optional[dict] = None,
+    v2: bool = False
 ):
     """
     A simple shorthand for using :class:`matchzoo.Preparer`.
@@ -46,5 +47,6 @@ def prepare(
         data_pack=data_pack,
         callback=callback,
         preprocessor=preprocessor,
-        embedding=embedding
+        embedding=embedding,
+        v2=v2
     )

--- a/matchzoo/dataloader/__init__.py
+++ b/matchzoo/dataloader/__init__.py
@@ -1,5 +1,6 @@
 from . import callbacks
-from .dataset import Dataset
-from .dataloader import DataLoader
-from .dataloader_builder import DataLoaderBuilder
-from .dataset_builder import DatasetBuilder
+from .dataset import Dataset, DatasetV2
+from .dataloader import DataLoader, DataLoaderV2
+from .dataloader_builder import DataLoaderBuilder, DataLoaderBuilderV2
+from .dataset_builder import DatasetBuilder, DatasetBuilderV2
+from .data_generator import DataGenerator, DataGeneratorBuilder

--- a/matchzoo/dataloader/callbacks/padding.py
+++ b/matchzoo/dataloader/callbacks/padding.py
@@ -1,8 +1,34 @@
 import typing
+from collections import Iterable
 
 import numpy as np
 
 from matchzoo.engine.base_callback import BaseCallback
+
+
+def infer_dtype(value):
+    """Infer the dtype for the features.
+
+    It is required as the input is usually array of objects before padding.
+    """
+    while isinstance(value, (list, tuple)) and len(
+            value) > 0:
+        value = value[0]
+
+    if not isinstance(value, Iterable):
+        return np.array(value).dtype
+
+    if value is not None and len(value) > 0 and np.issubdtype(
+            np.array(value).dtype, np.object):
+        dtype = np.array(value[0]).dtype
+    else:
+        dtype = value.dtype
+
+    # Single Precision
+    if dtype == np.double:
+        dtype = np.float32
+
+    return dtype
 
 
 def _padding_2D(input, output, mode: str = 'pre'):
@@ -122,24 +148,26 @@ class BasicPadding(BaseCallback):
             pad_length_right = self._fixed_length_right
 
         for key, value in x.items():
+            dtype = infer_dtype(value)
+
             if key == 'text_left':
                 padded_value = np.full([batch_size, pad_length_left],
-                                       self._pad_word_value, dtype=value.dtype)
+                                       self._pad_word_value, dtype=dtype)
                 _padding_2D(value, padded_value, self._pad_word_mode)
             elif key == 'text_right':
                 padded_value = np.full([batch_size, pad_length_right],
-                                       self._pad_word_value, dtype=value.dtype)
+                                       self._pad_word_value, dtype=dtype)
                 _padding_2D(value, padded_value, self._pad_word_mode)
             elif key == 'ngram_left':
                 padded_value = np.full(
                     [batch_size, pad_length_left, ngram_length],
-                    self._pad_ngram_value, dtype=value.dtype
+                    self._pad_ngram_value, dtype=dtype
                 )
                 _padding_3D(value, padded_value, self._pad_ngram_mode)
             elif key == 'ngram_right':
                 padded_value = np.full(
                     [batch_size, pad_length_right, ngram_length],
-                    self._pad_ngram_value, dtype=value.dtype
+                    self._pad_ngram_value, dtype=dtype
                 )
                 _padding_3D(value, padded_value, self._pad_ngram_mode)
             else:
@@ -193,18 +221,20 @@ class DRMMPadding(BaseCallback):
             if key != 'text_left' and key != 'text_right' and \
                     key != 'match_histogram':
                 continue
-            elif key == 'text_left':
+            dtype = infer_dtype(value)
+
+            if key == 'text_left':
                 padded_value = np.full([batch_size, pad_length_left],
-                                       self._pad_value, dtype=value.dtype)
+                                       self._pad_value, dtype=dtype)
                 _padding_2D(value, padded_value, self._pad_mode)
             elif key == 'text_right':
                 padded_value = np.full([batch_size, pad_length_right],
-                                       self._pad_value, dtype=value.dtype)
+                                       self._pad_value, dtype=dtype)
                 _padding_2D(value, padded_value, self._pad_mode)
             else:  # key == 'match_histogram'
                 padded_value = np.full(
                     [batch_size, pad_length_left, bin_size],
-                    self._pad_value, dtype=value.dtype)
+                    self._pad_value, dtype=dtype)
                 _padding_3D(value, padded_value, self._pad_mode)
             x[key] = padded_value
 

--- a/matchzoo/dataloader/data_generator.py
+++ b/matchzoo/dataloader/data_generator.py
@@ -1,0 +1,337 @@
+import math
+import typing
+from collections import Iterable
+
+import matchzoo as mz
+import numpy as np
+import pandas as pd
+from matchzoo.engine.base_callback import BaseCallback
+
+
+class DataGenerator(object):
+    """
+    Data Generator.
+
+    Used to divide a :class:`matchzoo.DataPack` into batches. This is helpful
+    for generating batch-wise features and delaying data preprocessing to the
+    `fit` time.
+
+    See `tutorials/data_handling.ipynb` for a walkthrough.
+
+    :param data_pack: DataPack to generator data from.
+    :param mode: One of "point", "pair", and "list". (default: "point")
+    :param num_dup: Number of duplications per instance, only effective when
+        `mode` is "pair". (default: 1)
+    :param num_neg: Number of negative samples per instance, only effective
+        when `mode` is "pair". (default: 1)
+    :param resample: Either to resample for each epoch, only effective when
+        `mode` is "pair". (default: `True`)
+    :param batch_size: Batch size. (default: 128)
+    :param shuffle: Either to shuffle the samples/instances. (default: `True`)
+    :param callbacks: Callbacks. See `matchzoo.data_generator.callbacks` for
+        more details.
+
+    Examples::
+        >>> import numpy as np
+        >>> import matchzoo as mz
+        >>> np.random.seed(0)
+        >>> data_pack = mz.datasets.toy.load_data()
+        >>> batch_size = 8
+
+    To generate data points:
+        >>> point_gen = DataGenerator(
+        ...     data_pack=data_pack,
+        ...     batch_size=batch_size
+        ... )
+        >>> len(point_gen)
+        13
+        >>> x, y = point_gen[0]
+        >>> for key, value in sorted(x.items()):
+        ...     print(key, str(value)[:30])
+        id_left ['Q6' 'Q17' 'Q1' 'Q13' 'Q16' '
+        id_right ['D6-6' 'D17-1' 'D1-2' 'D13-3'
+        text_left ['how long is the term for fed
+        text_right ['See Article I and Article II
+
+    To generate data pairs:
+        >>> pair_gen = DataGenerator(
+        ...     data_pack=data_pack,
+        ...     mode='pair',
+        ...     num_dup=4,
+        ...     num_neg=4,
+        ...     batch_size=batch_size,
+        ...     shuffle=False
+        ... )
+        >>> len(pair_gen)
+        3
+        >>> x, y = pair_gen[0]
+        >>> for key, value in sorted(x.items()):
+        ...     print(key, str(value)[:30])
+        id_left ['Q1' 'Q1' 'Q1' 'Q1' 'Q1' 'Q1'
+        id_right ['D1-3' 'D1-4' 'D1-0' 'D1-1' '
+        text_left ['how are glacier caves formed
+        text_right ['A glacier cave is a cave for
+
+    To generate data lists:
+        # TODO:
+
+    """
+
+    def __init__(
+            self,
+            data_pack: mz.DataPack,
+            mode='point',
+            num_dup: int = 1,
+            num_neg: int = 1,
+            resample: bool = True,
+            batch_size: int = 128,
+            shuffle: bool = True,
+            callbacks: typing.List[BaseCallback] = None
+    ):
+        """Init."""
+        data_pack = data_pack.copy()
+        if callbacks is None:
+            callbacks = []
+
+        if mode not in ('point', 'pair', 'list'):
+            raise ValueError(f"{mode} is not a valid mode type."
+                             f"Must be one of `point`, `pair` or `list`.")
+
+        self._mode = mode
+        self._num_dup = num_dup
+        self._num_neg = num_neg
+        self._batch_size = batch_size
+        self._shuffle = shuffle
+        self._resample = resample
+        self._orig_relation = data_pack.relation
+        self._callbacks = callbacks
+
+        if mode == 'pair':
+            data_pack.relation = self._reorganize_pair_wise(
+                data_pack.relation,
+                num_dup=num_dup,
+                num_neg=num_neg
+            )
+
+        self._data_pack = data_pack
+        self._batch_indices = None
+
+        self.reset_index()
+
+    def __getitem__(self, item) -> typing.Tuple[dict, np.ndarray]:
+        """Get a batch from index idx.
+
+        :param item: the index of the batch.
+        """
+        if isinstance(item, slice):
+            indices = sum(self._batch_indices[item], [])
+        elif isinstance(item, Iterable):
+            indices = [self._batch_indices[i] for i in item]
+        else:
+            indices = self._batch_indices[item]
+        batch_data_pack = self._data_pack[indices]
+        self._handle_callbacks_on_batch_data_pack(batch_data_pack)
+        x, y = batch_data_pack.unpack()
+        self._handle_callbacks_on_batch_unpacked(x, y)
+        return x, y
+
+    def __len__(self) -> int:
+        """Get the total number of batches."""
+        return len(self._batch_indices)
+
+    def __iter__(self):
+        """Create a generator that iterate over the Batches."""
+        self.sample()
+        for i in range(len(self)):
+            yield self[i]
+
+    def on_epoch_end(self):
+        """Reorganize the index array while epoch is ended."""
+        if self._mode == 'pair' and self._resample:
+            self._data_pack.relation = self._reorganize_pair_wise(
+                relation=self._orig_relation,
+                num_dup=self._num_dup,
+                num_neg=self._num_neg
+            )
+        self.reset_index()
+
+    def sample(self):
+        """Resample the batches if applicable."""
+        self.on_epoch_end()
+
+    def reset_index(self):
+        """
+        Set the :attr:`index_array`.
+
+        Here the :attr:`index_array` records the index of all the instances.
+        """
+        # index pool: index -> instance index
+        if self._mode == 'point':
+            num_instances = len(self._data_pack)
+            index_pool = list(range(num_instances))
+        elif self._mode == 'pair':
+            index_pool = []
+            step_size = self._num_neg + 1
+            num_instances = int(len(self._data_pack) / step_size)
+            for i in range(num_instances):
+                lower = i * step_size
+                upper = (i + 1) * step_size
+                indices = list(range(lower, upper))
+                if indices:
+                    index_pool.append(indices)
+        elif self._mode == 'list':
+            raise NotImplementedError(
+                f'{self._mode} data generator not implemented.')
+        else:
+            raise ValueError(f"{self._mode} is not a valid mode type"
+                             f"Must be one of `point`, `pair` or `list`.")
+
+        if self._shuffle:
+            np.random.shuffle(index_pool)
+
+        # batch_indices: index -> batch of indices
+        self._batch_indices = []
+        for i in range(math.ceil(num_instances / self._batch_size)):
+            lower = self._batch_size * i
+            upper = self._batch_size * (i + 1)
+            candidates = index_pool[lower:upper]
+            if self._mode == 'pair':
+                candidates = sum(candidates, [])
+            if candidates:
+                self._batch_indices.append(candidates)
+
+    def _handle_callbacks_on_batch_data_pack(self, batch_data_pack):
+        for callback in self._callbacks:
+            callback.on_batch_data_pack(batch_data_pack)
+
+    def _handle_callbacks_on_batch_unpacked(self, x, y):
+        for callback in self._callbacks:
+            callback.on_batch_unpacked(x, y)
+
+    @property
+    def callbacks(self):
+        """`callbacks` getter."""
+        return self._callbacks
+
+    @callbacks.setter
+    def callbacks(self, value):
+        """`callbacks` setter."""
+        self._callbacks = value
+
+    @property
+    def num_neg(self):
+        """`num_neg` getter."""
+        return self._num_neg
+
+    @num_neg.setter
+    def num_neg(self, value):
+        """`num_neg` setter."""
+        self._num_neg = value
+        self.reset_index()
+
+    @property
+    def num_dup(self):
+        """`num_dup` getter."""
+        return self._num_dup
+
+    @num_dup.setter
+    def num_dup(self, value):
+        """`num_dup` setter."""
+        self._num_dup = value
+        self.reset_index()
+
+    @property
+    def mode(self):
+        """`mode` getter."""
+        return self._mode
+
+    @mode.setter
+    def mode(self, value):
+        """`mode` setter."""
+        self._mode = value
+        self.reset_index()
+
+    @property
+    def batch_size(self):
+        """`batch_size` getter."""
+        return self._batch_size
+
+    @batch_size.setter
+    def batch_size(self, value):
+        """`batch_size` setter."""
+        self._batch_size = value
+        self.reset_index()
+
+    @property
+    def shuffle(self):
+        """`shuffle` getter."""
+        return self._shuffle
+
+    @shuffle.setter
+    def shuffle(self, value):
+        """`shuffle` setter."""
+        self._shuffle = value
+        self.reset_index()
+
+    @property
+    def batch_indices(self):
+        """`batch_indices` getter."""
+        return self._batch_indices
+
+    @classmethod
+    def _reorganize_pair_wise(
+            cls,
+            relation: pd.DataFrame,
+            num_dup: int = 1,
+            num_neg: int = 1
+    ):
+        """Re-organize the data pack as pair-wise format."""
+        pairs = []
+        groups = relation.sort_values(
+            'label', ascending=False).groupby('id_left')
+        for idx, group in groups:
+            labels = group.label.unique()
+            for label in labels[:-1]:
+                pos_samples = group[group.label == label]
+                pos_samples = pd.concat([pos_samples] * num_dup)
+                neg_samples = group[group.label < label]
+                for _, pos_sample in pos_samples.iterrows():
+                    pos_sample = pd.DataFrame([pos_sample])
+                    neg_sample = neg_samples.sample(num_neg, replace=True)
+                    pairs.extend((pos_sample, neg_sample))
+        new_relation = pd.concat(pairs, ignore_index=True)
+        return new_relation
+
+
+class DataGeneratorBuilder(object):
+    """
+    Data Generator Bulider. In essense a wrapped partial function.
+
+    Example:
+        >>> import matchzoo as mz
+        >>> builder = mz.dataloader.DataGeneratorBuilder(mode='pair', batch_size=32)
+        >>> data = mz.datasets.toy.load_data()
+        >>> gen = builder.build(data)
+        >>> type(gen)
+        <class 'matchzoo.dataloader.data_generator.DataGenerator'>
+        >>> gen.batch_size
+        32
+        >>> gen_64 = builder.build(data, batch_size=64)
+        >>> gen_64.batch_size
+        64
+
+    """
+
+    def __init__(self, **kwargs):
+        """Init."""
+        self._kwargs = kwargs
+
+    def build(self, data_pack, **kwargs) -> DataGenerator:
+        """
+        Build a DataGenerator.
+
+        :param data_pack: DataPack to build upon.
+        :param kwargs: Additional keyword arguments to override the keyword
+            arguments passed in `__init__`.
+        """
+        return DataGenerator(data_pack, **{**self._kwargs, **kwargs})

--- a/matchzoo/dataloader/dataloader.py
+++ b/matchzoo/dataloader/dataloader.py
@@ -1,16 +1,15 @@
 """Basic data loader."""
+import collections
+import math
 import typing
 
-import math
-import random
-import collections
 import numpy as np
 import torch
-from torch.utils import data
-
-from matchzoo.engine.base_callback import BaseCallback
+from matchzoo.dataloader.dataset import DatasetV2
 from matchzoo.dataloader.sampler import (SequentialSampler, RandomSampler,
                                          SortedSampler, BatchSampler)
+from matchzoo.engine.base_callback import BaseCallback
+from torch.utils import data
 
 
 class DataLoader(object):
@@ -201,3 +200,135 @@ def mz_collate(batch):
         batch_y = np.array(batch_y)
 
     return batch_x, batch_y
+
+
+class DataLoaderV2(DataLoader):
+    """
+    DataLoader that loads batches of data from a Dataset.
+
+    :param dataset: The Dataset object to load data from.
+    :param batch_size: Batch_size. (default: 32)
+    :param device: The desired device of returned tensor. Default: if None,
+        use the current device. If `torch.device` or int, use device specified
+        by user. If list, the first item will be used.
+    :param stage: One of "train", "dev", and "test". (default: "train")
+    :param resample: Whether to resample data between epochs. only effective
+        when `mode` of dataset is "pair". (default: `True`)
+    :param shuffle: Whether to shuffle data between epochs. (default: `False`)
+    :param sort: Whether to sort data according to length_right. (default:
+        `True`)
+    :param callback: BaseCallback. See
+        `matchzoo.engine.base_callback.BaseCallback` for more details.
+    :param pin_momory: If set to `True`, tensors will be copied into
+        pinned memory. (default: `False`)
+    :param timeout: The timeout value for collecting a batch from workers. (
+        default: 0)
+    :param num_workers: The number of subprocesses to use for data loading. 0
+        means that the data will be loaded in the main process. (default: 0)
+    :param worker_init_fn: If not ``None``, this will be called on each
+        worker subprocess with the worker id (an int in [0, num_workers - 1])
+        as input, after seeding and before data loading. (default: None)
+
+    Examples:
+        >>> import matchzoo as mz
+        >>> data_pack = mz.datasets.toy.load_data(stage='train')
+        >>> preprocessor = mz.preprocessors.BasicPreprocessor()
+        >>> data_processed = preprocessor.fit_transform(data_pack)
+        >>> padding_callback = mz.dataloader.callbacks.BasicPadding()
+        >>> dataset = mz.dataloader.DatasetV2(data_processed, mode='point',
+        ...                                   callbacks=[padding_callback])
+        >>> dataloader = mz.dataloader.DataLoaderV2(dataset, stage='train')
+        >>> len(dataloader)
+        1
+
+    """
+
+    def __init__(
+            self,
+            dataset: DatasetV2,
+            device: typing.Union[torch.device, int, list, None] = None,
+            stage='train',
+            callback: BaseCallback = None,
+            pin_memory: bool = False,
+            timeout: int = 0,
+            num_workers: int = 0,
+            worker_init_fn=None,
+    ):
+        """Init."""
+        if stage not in ('train', 'dev', 'test'):
+            raise ValueError(f"{stage} is not a valid stage type."
+                             f"Must be one of `train`, `dev`, `test`.")
+
+        if isinstance(device, list) and len(device):
+            device = device[0]
+        elif not (isinstance(device, torch.device) or isinstance(device,
+                                                                 int)):
+            device = torch.device(
+                "cuda" if torch.cuda.is_available() else "cpu")
+
+        self._dataset = dataset
+        self._pin_momory = pin_memory
+        self._timeout = timeout
+        self._num_workers = num_workers
+        self._worker_init_fn = worker_init_fn
+        self._device = device
+        self._stage = stage
+        self._callback = callback
+        self._dataloader = data.DataLoader(
+            self._dataset,
+            batch_size=None,
+            shuffle=False,
+            collate_fn=lambda x: x,
+            batch_sampler=None,
+            num_workers=self._num_workers,
+            pin_memory=self._pin_momory,
+            timeout=self._timeout,
+            worker_init_fn=self._worker_init_fn,
+        )
+
+    def __len__(self) -> int:
+        """Get the total number of batches."""
+        return len(self._dataset)
+
+    @property
+    def id_left(self) -> np.ndarray:
+        """`id_left` getter."""
+        x, _ = self._dataset[:]
+        return x['id_left']
+
+    @property
+    def label(self) -> np.ndarray:
+        """`label` getter."""
+        _, y = self._dataset[:]
+        return y.squeeze() if y is not None else None
+
+    def __iter__(self) -> typing.Tuple[dict, torch.tensor]:
+        """Iteration."""
+        for batch_data in self._dataloader:
+            x, y = batch_data
+            self._handle_callbacks_on_batch_unpacked(x, y)
+
+            batch_x = {}
+            for key, value in x.items():
+                if key == 'id_left' or key == 'id_right':
+                    continue
+                batch_x[key] = torch.tensor(
+                    value,
+                    device=self._device)
+
+            if self._stage == 'test':
+                yield batch_x, None
+            else:
+                if y.dtype == 'int':  # task='classification'
+                    batch_y = torch.tensor(
+                        y.squeeze(axis=-1), dtype=torch.long,
+                        device=self._device)
+                else:  # task='ranking'
+                    batch_y = torch.tensor(
+                        y, dtype=torch.float,
+                        device=self._device)
+                yield batch_x, batch_y
+
+    def _handle_callbacks_on_batch_unpacked(self, x, y):
+        if self._callback is not None:
+            self._callback.on_batch_unpacked(x, y)

--- a/matchzoo/dataloader/dataloader_builder.py
+++ b/matchzoo/dataloader/dataloader_builder.py
@@ -37,3 +37,35 @@ class DataLoaderBuilder(object):
         return mz.dataloader.DataLoader(
             dataset, **{**self._kwargs, **kwargs}
         )
+
+
+class DataLoaderBuilderV2(DataLoaderBuilder):
+    """
+    DataLoader Bulider. In essense a wrapped partial function.
+
+    Example:
+        >>> import matchzoo as mz
+        >>> padding_callback = mz.dataloader.callbacks.BasicPadding()
+        >>> builder = mz.dataloader.DataLoaderBuilderV2(
+        ...     stage='train'
+        ... )
+        >>> data_pack = mz.datasets.toy.load_data()
+        >>> preprocessor = mz.preprocessors.BasicPreprocessor()
+        >>> data_processed = preprocessor.fit_transform(data_pack)
+        >>> dataset = mz.dataloader.DatasetV2(data_processed, mode='point')
+        >>> dataloder = builder.build(dataset)
+        >>> type(dataloder)
+        <class 'matchzoo.dataloader.dataloader.DataLoaderV2'>
+    """
+
+    def build(self, dataset, **kwargs) -> DataLoader:
+        """
+        Build a DataLoader.
+
+        :param dataset: Dataset to build upon.
+        :param kwargs: Additional keyword arguments to override the keyword
+            arguments passed in `__init__`.
+        """
+        return mz.dataloader.DataLoaderV2(
+            dataset, **{**self._kwargs, **kwargs}
+        )

--- a/matchzoo/dataloader/dataset_builder.py
+++ b/matchzoo/dataloader/dataset_builder.py
@@ -33,3 +33,31 @@ class DatasetBuilder(object):
         return mz.dataloader.Dataset(
             data_pack, **{**self._kwargs, **kwargs}
         )
+
+
+class DatasetBuilderV2(DatasetBuilder):
+    """
+    Dataset Bulider V2. In essense a wrapped partial function.
+
+    Example:
+        >>> import matchzoo as mz
+        >>> builder = mz.dataloader.DatasetBuilderV2(
+        ...     mode='point'
+        ... )
+        >>> data = mz.datasets.toy.load_data()
+        >>> gen = builder.build(data)
+        >>> type(gen)
+        <class 'matchzoo.dataloader.dataset.DatasetV2'>
+    """
+
+    def build(self, data_pack, **kwargs) -> Dataset:
+        """
+        Build a Dataset.
+
+        :param data_pack: DataPack to build upon.
+        :param kwargs: Additional keyword arguments to override the keyword
+            arguments passed in `__init__`.
+        """
+        return mz.dataloader.DatasetV2(
+            data_pack, **{**self._kwargs, **kwargs}
+        )

--- a/matchzoo/preprocessors/bert_preprocessor.py
+++ b/matchzoo/preprocessors/bert_preprocessor.py
@@ -34,6 +34,7 @@ class BertPreprocessor(BasePreprocessor):
 
         :return: Transformed data as :class:`DataPack` object.
         """
+        data_pack = data_pack.copy()
         data_pack.apply_on_text(self._tokenizer.encode,
                                 mode='both', inplace=True, verbose=verbose)
         data_pack.append_text_length(inplace=True, verbose=verbose)

--- a/matchzoo/preprocessors/naive_preprocessor.py
+++ b/matchzoo/preprocessors/naive_preprocessor.py
@@ -54,6 +54,7 @@ class NaivePreprocessor(BasePreprocessor):
 
         :return: Transformed data as :class:`DataPack` object.
         """
+        data_pack = data_pack.copy()
         units_ = self._default_units()
         units_.append(self._context['vocab_unit'])
         units_.append(

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pytorch-transformers >= 1.1.0
 tabulate >= 0.8.3
 nltk >= 3.4.3
 numpy >= 1.16.4
-tqdm >= 4.32.2
+tqdm == 4.32.2
 dill >= 0.2.9
 hyperopt == 0.1.2
 pandas == 0.24.2

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -33,13 +33,18 @@ def embedding():
     return mz.datasets.toy.load_embedding()
 
 
+@pytest.fixture(scope='module', params=[False, True])
+def v2(request):
+    return request.param
+
 @pytest.fixture(scope='module')
-def setup(task, model_class, train_raw, embedding):
+def setup(task, model_class, train_raw, embedding, v2):
     return mz.auto.prepare(
         task=task,
         model_class=model_class,
         data_pack=train_raw,
-        embedding=embedding
+        embedding=embedding,
+        v2=v2
     )
 
 


### PR DESCRIPTION
To solve #109 .  

* Added DataGenerator, DataLoaderV2 and DatasetV2. 

In this PR, batching, shuffling, and sampling are handled by DataGenerator inside DataSetV2, then DataLoader does not need to read each individual data separately for batching. As a result, DataloaderV2 is 200x faster than DataLoader.

Example: https://gist.github.com/matthew-z/2c88fe2916d05558beae3a590acccbfe

Current PR is just a simple prototype of how to solve this issue... 

BTW, as we assume that all data should fit RAM, DataLoader is not really necessary, I think. 