### PR TITLE
Change device type from `int` to `torch.device`

### DIFF
--- a/matchzoo/trainers/trainer.py
+++ b/matchzoo/trainers/trainer.py
@@ -161,6 +161,9 @@ class Trainer:
                     "cuda" if torch.cuda.is_available() else "cpu")
             self._device = device
 
+        if isinstance(self._device, int):
+            self._device = torch.device(f"cuda:{self._device}")
+
         self._model.to(self._device)
 
     def _load_path(


### PR DESCRIPTION
> ... When loading a model on a GPU that was trained and saved on CPU, set the `map_location` argument in the torch.load() function to `cuda:device_id`. This loads the model to a given GPU device ...

Previously, `map_location` argument is an `int` instance, which will cause an error "TypeError: 'int' object is not callable".